### PR TITLE
Add prototypes for functions that aren't defined

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -34,7 +34,9 @@ layers = vkEnumerateInstanceLayerProperties()
 layers = [l.layerName for l in layers]
 print("availables layers: %s\n" % layers)
 
-layers = ['VK_LAYER_LUNARG_standard_validation']
+#GAM - Not defined for me on Windows 8.1 Nvidia drivers
+#layers = ['VK_LAYER_LUNARG_standard_validation']
+layers = []
 extensions = ['VK_KHR_surface', 'VK_EXT_debug_report']
 
 if platform.system() == 'Windows':
@@ -131,7 +133,7 @@ def surface_win32():
     surface_create = VkWin32SurfaceCreateInfoKHR(
         sType=VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR,
         hinstance=get_instance(wm_info.info.win.window),
-        hwdn=wm_info.info.win.window,
+        hwnd=wm_info.info.win.window,
         flags=0)
     return vkCreateWin32SurfaceKHR(instance, surface_create, None)
 

--- a/vulkan/__init__.py
+++ b/vulkan/__init__.py
@@ -5165,6 +5165,9 @@ _instance_ext_funcs = {
     'vkCmdProcessCommandsNVX':_wrap_vkCmdProcessCommandsNVX,
 }
 
+_instance_ext_func_prototypes = {
+    "vkCreateWin32SurfaceKHR": "VkResult (*)(VkInstance instance, const void* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)"
+}
 
 _device_ext_funcs = {
     'vkCmdSetViewportWScalingNV':_wrap_vkCmdSetViewportWScalingNV,
@@ -5231,7 +5234,10 @@ def vkGetInstanceProcAddr(instance, pName):
         raise ProcedureNotFoundError()
     if not pName in _instance_ext_funcs:
         raise ExtensionNotSupportedError()
-    fn = ffi.cast('PFN_' + pName, fn)
+    if pName in _instance_ext_func_prototypes:
+        fn = ffi.cast(_instance_ext_func_prototypes[pName], fn)
+    else:
+        fn = ffi.cast('PFN_' + pName, fn)
     return _instance_ext_funcs[pName](fn)
 
 


### PR DESCRIPTION
Fix to https://github.com/realitix/vulkan/issues/5 so that function prototypes that aren't in the DLL are manually defined

Also fixes a typo in the example code