### PR TITLE
Clarify error message

### DIFF
--- a/generator/vulkan.template.py
+++ b/generator/vulkan.template.py
@@ -105,8 +105,9 @@ for name in _lib_names:
     except OSError:
         pass
 else:
-    raise OSError('Cannot find Vulkan SDK version ' + __version__ + '. '
-                  'Please install it')
+    raise OSError('Cannot find Vulkan SDK version. Please ensure that it is '
+                  'installed and that the <sdk_root>/<version>/lib/ folder is '
+                  'in the library path')
 
 
 {# Add enums #}


### PR DESCRIPTION
I just wanted to clarify the error message that shows up when the library can't find the .so/.dll

The previous error message implied that the error had something to do with the vulkan version (false, as far as I can tell) and also didn't really indicate that the library just may not have been in the loading path. It's a really small thing, but I thought I'd submit a PR anyways

Also, random question. Why is there so much code duplication between vulkan.template.py and __init__.py?