### PR TITLE
Performance improvement in _callApi

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -168,6 +168,7 @@ queue_family_graphic_index = -1
 queue_family_present_index = -1
 
 for i, queue_family in enumerate(queue_families):
+    # Currently, we set present index like graphic index
     support_present = vkGetPhysicalDeviceSurfaceSupportKHR(
         physicalDevice=physical_device,
         queueFamilyIndex=i,
@@ -175,8 +176,9 @@ for i, queue_family in enumerate(queue_families):
     if (queue_family.queueCount > 0 and
        queue_family.queueFlags & VK_QUEUE_GRAPHICS_BIT):
         queue_family_graphic_index = i
-    if queue_family.queueCount > 0 and support_present:
         queue_family_present_index = i
+    # if queue_family.queueCount > 0 and support_present:
+    #     queue_family_present_index = i
 
 print("indice of selected queue families, graphic: %s, presentation: %s\n" % (
     queue_family_graphic_index, queue_family_present_index))

--- a/vulkan/__init__.py
+++ b/vulkan/__init__.py
@@ -2418,19 +2418,17 @@ def VkSurfaceFormat2KHR(sType=None,pNext=None,surfaceFormat=None,):
 def VkSharedPresentSurfaceCapabilitiesKHR(sType=None,pNext=None,sharedPresentSupportedUsageFlags=None,):
     return _new('VkSharedPresentSurfaceCapabilitiesKHR', sType=sType,pNext=pNext,sharedPresentSupportedUsageFlags=sharedPresentSupportedUsageFlags)
 
-
+def _(x, _type):
+    if x is None:
+        return ffi.NULL
+    if _type.kind == 'pointer':
+        ptr, _ = _cast_ptr(x, _type)
+        return ptr
+    return x
+    
 def _callApi(fn, *args):
-    def _(x, _type):
-        if x is None:
-            return ffi.NULL
-        if _type.kind == 'pointer':
-            ptr, _ = _cast_ptr(x, _type)
-            return ptr
-        return x
-
     fn_args = [_(i, j) for i, j in zip(args, ffi.typeof(fn).args)]
     return fn(*fn_args)
-
 
 
 


### PR DESCRIPTION
In my test setup the _callApi function was taking over 90% of the render thread time.
This small change reduced that to 70-75% and improved performance a lot by giving more time to other tasks.