### PR TITLE
Remove unnecessary code from SDL2 example

### DIFF
--- a/example/example_sdl2.py
+++ b/example/example_sdl2.py
@@ -47,9 +47,6 @@ extensions = vkEnumerateInstanceExtensionProperties(None)
 extensions = [e.extensionName for e in extensions]
 print("availables extensions: %s\n" % extensions)
 
-# we select only swapchain extension
-extensions = [VK_KHR_SWAPCHAIN_EXTENSION_NAME]
-
 layers = vkEnumerateInstanceLayerProperties()
 layers = [l.layerName for l in layers]
 print("availables layers: %s\n" % layers)


### PR DESCRIPTION
Line 58 defines the surface and debug extensions. Line 51 has no effect and would be in the wrong place anyway, as that is a device extension (VK_KHR_SWAPCHAIN_EXTENSION_NAME).