### PR TITLE
Fix AMD support in sdl2 example

### DIFF
--- a/example/example_sdl2.py
+++ b/example/example_sdl2.py
@@ -195,6 +195,9 @@ extensions = vkEnumerateDeviceExtensionProperties(physicalDevice=physical_device
 extensions = [e.extensionName for e in extensions]
 print("availables device extensions: %s\n" % extensions)
 
+#only use the extensions necessary
+extensions = [VK_KHR_SWAPCHAIN_EXTENSION_NAME]
+
 queues_create = [VkDeviceQueueCreateInfo(sType=VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
                                          queueFamilyIndex=i,
                                          queueCount=1,


### PR DESCRIPTION
We need to limit the device extensions loaded.