### PR TITLE
Changed name of library for MacOS from libMoltenVK.dylib to libvulkan…

### DIFF
--- a/example/contribs/example_glfw.py
+++ b/example/contribs/example_glfw.py
@@ -145,7 +145,7 @@ class HelloTriangleApplication(object):
     def __initWindow(self):
         glfw.init()
 
-        #glfw.window_hint(glfw.CLIENT_API, glfw.NO_API)
+        glfw.window_hint(glfw.CLIENT_API, glfw.NO_API)
         glfw.window_hint(glfw.RESIZABLE, False)
 
         self.__window = glfw.create_window(WIDTH, HEIGHT, "Vulkan", None, None)

--- a/vulkan/_vulkan.py
+++ b/vulkan/_vulkan.py
@@ -94,7 +94,7 @@ _cast_ptr = _cast_ptr3 if PY3 else _cast_ptr2
 
 
 # Load SDK
-_lib_names = ('libvulkan.so.1', 'vulkan-1.dll', 'libMoltenVK.dylib')
+_lib_names = ('libvulkan.so.1', 'vulkan-1.dll', 'libvulkan.dylib')
 for name in _lib_names:
     try:
         lib = ffi.dlopen(name)


### PR DESCRIPTION
Changed name of library for MacOS from `libMoltenVK.dylib` to `libvulkan.dylib` to support the official LunarG SDK releases.  When using the LunarG vulkan SDK, you get a really frustrating error when trying to create a surface using pyGLFW (as in `example_glfw.py`). Without this change, glfw reports this error: `Cocoa: Vulkan instance missing VK_MVK_macos_surface extension`.

I created a cask for homebrew to install the vulkan sdk.  To install: `brew cask install vulkan-sdk`, and also add paths to `~/.bash_profile` per the cask caveats.