### PR TITLE
Use Iterable from collections.abc

### DIFF
--- a/generator/vulkan.template.py
+++ b/generator/vulkan.template.py
@@ -71,7 +71,7 @@ def _cast_ptr2(x, _type):
             return ffi.addressof(x), x
         return x, x
 
-    if isinstance(x, _collections.Iterable):
+    if isinstance(x, _collections.abc.Iterable):
         if _type.item.kind == 'pointer':
             ptrs = [_cast_ptr(i, _type.item) for i in x]
             ret = ffi.new(_type.item.cname+'[]', [i for i, _ in ptrs])

--- a/vulkan/_vulkan.py
+++ b/vulkan/_vulkan.py
@@ -71,7 +71,7 @@ def _cast_ptr2(x, _type):
             return ffi.addressof(x), x
         return x, x
 
-    if isinstance(x, _collections.Iterable):
+    if isinstance(x, _collections.abc.Iterable):
         if _type.item.kind == 'pointer':
             ptrs = [_cast_ptr(i, _type.item) for i in x]
             ret = ffi.new(_type.item.cname+'[]', [i for i, _ in ptrs])


### PR DESCRIPTION
Iterable was removed from the collections module in python ~3.8. It has
been in collections.abc since python 3.3.

fixes:
    File "/home/clayton/src/valve-infra/venv/lib/python3.10/site-packages/vulkan/_vulkan.py", line 74, in _cast_ptr2
      if isinstance(x, _collections.Iterable):
  AttributeError: module 'collections' has no attribute 'Iterable'