### PR TITLE
Update _vulkan.py

### DIFF
--- a/vulkan/_vulkan.py
+++ b/vulkan/_vulkan.py
@@ -26,7 +26,10 @@ def _cstr(x):
         return x
 
     if PY3:
-        return ffi.string(x).decode('ascii')
+        try:
+            return ffi.string(x).decode('ascii')
+        except UnicodeDecodeError:
+            return ffi.string(x).decode('utf-8')
     else:
         return ffi.string(x)
 
@@ -86,7 +89,10 @@ def _cast_ptr2(x, _type):
 
 def _cast_ptr3(x, _type):
     if isinstance(x, str):
-        x = x.encode('ascii')
+        try:
+            x = x.encode('ascii')
+        except UnicodeEncodeError:
+            x = x.encode('utf-8')
     return _cast_ptr2(x, _type)
 
 


### PR DESCRIPTION
adding support for encoding utf-8 and decoding utf-8 strings for support of Nerdfont and utf-8 symbols when using VK_EXT_debug_utils( `utils messenger` and `set object name`)

![image](https://user-images.githubusercontent.com/44575116/198337435-a229c945-2029-43bb-9162-922633b17d6d.png)
