### PR TITLE
Fix nested object weak references for lists

### DIFF
--- a/generator/vulkan.template.py
+++ b/generator/vulkan.template.py
@@ -82,6 +82,14 @@ def _cast_ptr2(x, _type):
         else:
             ret = ffi.new(_type.item.cname+'[]', x)
 
+        if isinstance(x, list):
+            iterable_references = []
+            for item in x:
+                if item in _weakkey_dict:
+                    iterable_references.append(_weakkey_dict[item])
+            if iterable_references:
+                _weakkey_dict[ret] = iterable_references
+
         return ret, ret
 
     return ffi.cast(_type, x), x

--- a/vulkan/__init__.py
+++ b/vulkan/__init__.py
@@ -1,3 +1,3 @@
 from vulkan._vulkan import * # noqa
 
-__version__ = '1.3.275.1'
+__version__ = '1.3.275.2'

--- a/vulkan/_vulkan.py
+++ b/vulkan/_vulkan.py
@@ -82,6 +82,14 @@ def _cast_ptr2(x, _type):
         else:
             ret = ffi.new(_type.item.cname+'[]', x)
 
+        if isinstance(x, list):
+            iterable_references = []
+            for item in x:
+                if item in _weakkey_dict:
+                    iterable_references.append(_weakkey_dict[item])
+            if iterable_references:
+                _weakkey_dict[ret] = iterable_references
+
         return ret, ret
 
     return ffi.cast(_type, x), x


### PR DESCRIPTION
Make C arrays created from lists hold weak references for the objects they contain.